### PR TITLE
Add datadog site as env variable to be able to override the default .com

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
   api-key:
     description: DataDog API Key
     required: true
+  dd-site:
+    description: DataDog Site
+    default: datadoghq.com
+    required: true
   path:
     description: Path of JavaScript Sourcemaps files
     default: ./dist/
@@ -36,6 +40,7 @@ runs:
     - name: Upload Sourcemaps
       shell: bash
       env:
+        DATADOG_SITE: ${{ inputs.dd-site }}
         DATADOG_API_KEY: ${{ inputs.api-key }}
       run: |
         datadog-ci sourcemaps upload ${{ inputs.path }} \


### PR DESCRIPTION
Adding ENV variable to be able to override the default datadoghq.com setting in https://github.com/DataDog/datadog-ci/blob/037401dfb90da166ec27b180056e2a40c5f9b6d9/src/commands/sourcemaps/upload.ts#L71