### PR TITLE
Use latest version of setup-node

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
   using: "composite"
   steps:
     - name: Set Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
 
     - name: Install DataDog CI
       shell: bash


### PR DESCRIPTION
Get rid of warnings about needing to use Node20, instead of Node 16.

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-node@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.